### PR TITLE
Update to latest omp sdk and make code compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,6 @@ add_samp_plugin(${PROJECT_NAME}
   lib/samp-ptl/ptl.h
 )
 
-target_include_directories(${PROJECT_NAME} PRIVATE lib)
+target_include_directories(${PROJECT_NAME} PRIVATE lib lib/samp-ptl)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE OMP-SDK)

--- a/src/main.cc
+++ b/src/main.cc
@@ -55,7 +55,7 @@ void PluginComponent::onInit(IComponentList *components) {
   }
 
   pawn_component_->getEventDispatcher().addEventHandler(this);
-  players_->getEventDispatcher().addEventHandler(this);
+  players_->getPlayerTextDispatcher().addEventHandler(this);
 
   plugin_data_[PLUGIN_DATA_LOGPRINTF] =
       reinterpret_cast<void *>(&PluginLogprintf);
@@ -65,12 +65,12 @@ void PluginComponent::onInit(IComponentList *components) {
   Plugin::DoLoad(plugin_data_);
 }
 
-void PluginComponent::onAmxLoad(void *amx) {
-  Plugin::DoAmxLoad(static_cast<AMX *>(amx));
+void PluginComponent::onAmxLoad(IPawnScript &script) {
+  Plugin::DoAmxLoad(static_cast<AMX *>(script.GetAMX()));
 };
 
-void PluginComponent::onAmxUnload(void *amx) {
-  Plugin::DoAmxUnload(static_cast<AMX *>(amx));
+void PluginComponent::onAmxUnload(IPawnScript &script) {
+  Plugin::DoAmxUnload(static_cast<AMX *>(script.GetAMX()));
 };
 
 void PluginComponent::onFree(IComponent *component) {
@@ -79,7 +79,7 @@ void PluginComponent::onFree(IComponent *component) {
 
     if (pawn_component_) {
       pawn_component_->getEventDispatcher().removeEventHandler(this);
-      players_->getEventDispatcher().removeEventHandler(this);
+      players_->getPlayerTextDispatcher().removeEventHandler(this);
     }
 
     pawn_component_ = nullptr;

--- a/src/main.h
+++ b/src/main.h
@@ -61,7 +61,7 @@
 
 class PluginComponent final : public IComponent,
                               public PawnEventHandler,
-                              public PlayerEventHandler {
+                              public PlayerTextEventHandler {
   PROVIDE_UID(0xa03b47c907a96c29);
 
   StringView componentName() const override;
@@ -72,9 +72,9 @@ class PluginComponent final : public IComponent,
 
   void onInit(IComponentList *components) override;
 
-  void onAmxLoad(void *amx) override;
+  void onAmxLoad(IPawnScript &script) override;
 
-  void onAmxUnload(void *amx) override;
+  void onAmxUnload(IPawnScript &script) override;
 
   void onFree(IComponent *component) override;
 


### PR DESCRIPTION
open.mp now uses different way of listening to player events (they are separated now) and pawn component SDK has changed to provide more API (and potentially remove the need of using samp-sdk)